### PR TITLE
chore!: drop Node 6 from testing matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,39 +1,9 @@
 
-## sky@1.0.7 (2019-12-04)
+## Unreleased (2019-12-04)
 
-#### :bug: Bug Fix
-* `Moon`
-  * [#4](https://github.com/siriwatknp/learn-lerna/pull/4) fix: update package.json ([@siriwatknp](https://github.com/siriwatknp))
-
-#### Committers: 1
-- Siriwat Kunaporn ([@siriwatknp](https://github.com/siriwatknp))
-
-
-## moon@2.1.2 (2019-12-04)
-
-#### :bug: Bug Fix
-* `Moon`
-  * [#4](https://github.com/siriwatknp/learn-lerna/pull/4) fix: update package.json ([@siriwatknp](https://github.com/siriwatknp))
-
-#### Committers: 1
-- Siriwat Kunaporn ([@siriwatknp](https://github.com/siriwatknp))
-
-
-## sky@1.0.6 (2019-12-04)
-
-#### :bug: Bug Fix
-* `Moon`
-  * [#2](https://github.com/siriwatknp/learn-lerna/pull/2) update package.json ([@siriwatknp](https://github.com/siriwatknp))
-
-#### Committers: 1
-- Siriwat Kunaporn ([@siriwatknp](https://github.com/siriwatknp))
-
-
-## moon@2.1.1 (2019-12-04)
-
-#### :bug: Bug Fix
-* `Moon`
-  * [#2](https://github.com/siriwatknp/learn-lerna/pull/2) update package.json ([@siriwatknp](https://github.com/siriwatknp))
+#### :rocket: New Feature
+* `Sky`
+  * [#6](https://github.com/siriwatknp/learn-lerna/pull/6) Test3 ([@siriwatknp](https://github.com/siriwatknp))
 
 #### Committers: 1
 - Siriwat Kunaporn ([@siriwatknp](https://github.com/siriwatknp))

--- a/packages/Sun/lib/Sun.js
+++ b/packages/Sun/lib/Sun.js
@@ -3,5 +3,5 @@
 module.exports = sun;
 
 function sun() {
-    return 'test'
+    return 'test2'
 }


### PR DESCRIPTION
BREAKING CHANGE: dropping Node 6 which hits end of life in April